### PR TITLE
feat: モバイルUI改善 - セーフエリア対応とレイアウト最適化

### DIFF
--- a/css/pages/chat.css
+++ b/css/pages/chat.css
@@ -539,7 +539,7 @@ body {
     }
 
     .message {
-        max-width: 90%;
+        max-width: 92%;
         gap: 10px;
     }
 
@@ -549,6 +549,7 @@ body {
         line-height: 1.6;
         word-break: keep-all;
         overflow-wrap: break-word;
+        max-width: 100%;
     }
 
     .message-avatar {
@@ -666,9 +667,23 @@ body {
         min-height: 32px;
     }
 
+    .message {
+        max-width: 95%;
+    }
+
     .message-content {
         font-size: 0.875rem;
         padding: 10px 12px;
+    }
+
+    .message-avatar {
+        width: 36px;
+        height: 36px;
+    }
+
+    .message-avatar svg {
+        width: 20px;
+        height: 20px;
     }
 
     .related-link-title {

--- a/css/pages/circulation.css
+++ b/css/pages/circulation.css
@@ -301,7 +301,7 @@ body {
     }
 
     .notice-box ul {
-        margin-left: 24px;
+        margin-left: 20px;
         font-size: 0.875rem;
         line-height: 1.6;
     }

--- a/css/pages/top.css
+++ b/css/pages/top.css
@@ -540,12 +540,12 @@
         line-height: 1.6;
     }
 
-    /* フローティングボタン */
+    /* フローティングボタン - iOSセーフエリア対応 */
     .floating-chat-btn {
         width: 56px;
         height: 56px;
-        bottom: 20px;
-        right: 16px;
+        bottom: max(20px, env(safe-area-inset-bottom, 20px));
+        right: max(16px, env(safe-area-inset-right, 16px));
     }
 
     .floating-chat-btn svg {


### PR DESCRIPTION
各画面のスマホ表示を改善しました。

主な変更点:
- top.css: フローティングボタンにiOSセーフエリア対応を追加
- chat.css: メッセージ表示幅を最適化（768px: 92%, 375px: 95%）
- chat.css: 小型スマホでアバターサイズを縮小（40px → 36px）
- circulation.css: 通知ボックスのマージンを最適化（24px → 20px）

技術的改善:
- env(safe-area-inset-*)でiPhoneのノッチ・ホームインジケーター対応
- max-width: 100%でコンテンツオーバーフロー防止
- 小型画面でのスペース有効活用

🤖 Generated with [Claude Code](https://claude.com/claude-code)