### PR TITLE
fix: モバイル表示でのログインドロップダウンのテキスト改行を修正

### DIFF
--- a/css/pages/top.css
+++ b/css/pages/top.css
@@ -578,7 +578,9 @@
         font-size: 0.875rem !important;
         gap: 10px !important;
         white-space: normal !important;
-        word-wrap: break-word !important;
+        word-break: keep-all !important;
+        overflow-wrap: break-word !important;
+        line-height: 1.5 !important;
     }
 
     .login-menu-item svg {
@@ -682,7 +684,9 @@
         font-size: 0.8125rem !important;
         gap: 8px !important;
         white-space: normal !important;
-        word-wrap: break-word !important;
+        word-break: keep-all !important;
+        overflow-wrap: break-word !important;
+        line-height: 1.5 !important;
     }
 
     .login-menu-item svg {


### PR DESCRIPTION
日本語テキストが文字単位で改行される問題を修正:
- word-break: keep-all を追加して単語境界で改行
- overflow-wrap: break-word で長い単語のみ折り返し
- line-height を調整して読みやすさを向上

これにより「被災労働者」「事業主」「社会保険労務士」「指定医療機関」が
適切に表示されるようになりました。