### PR TITLE
Fix step 7-8 bugs: Remove debug error summary and fix step 8 visibility

### DIFF
--- a/css/pages/application-form.css
+++ b/css/pages/application-form.css
@@ -1072,10 +1072,11 @@ body {
     }
 
     /* プログレスセクションを固定表示 - 縦方向の余白を大幅削減 */
+    /* ※ 2025年10月修正: position: relative に変更してコンテンツが隠れないようにする */
     .progress-section {
-        position: sticky !important;
+        position: relative !important;
         top: 0 !important;
-        z-index: 1100 !important; /* ヘッダーより前面に表示 */
+        z-index: 100 !important; /* ヘッダーより前面だが、コンテンツを隠さない */
         background: white;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         padding: var(--spacing-2) 0 !important; /* 上下の余白を8pxに削減 */

--- a/js/pages/application-form.js
+++ b/js/pages/application-form.js
@@ -842,41 +842,16 @@ function previousStep() {
 }
 
 // エラーサマリーを表示（デバッグ用）
+// ※ 2025年10月修正: ユーザー向けにはエラーサマリーを表示しない（コンソールログのみ）
 function showErrorSummary(message, stepElement) {
-    // 既存のエラーサマリーを削除
-    const existingSummary = stepElement.querySelector('.debug-error-summary');
-    if (existingSummary) {
-        existingSummary.remove();
-    }
-
-    // 新しいエラーサマリーを作成
-    const summary = document.createElement('div');
-    summary.className = 'debug-error-summary';
-    summary.style.cssText = `
-        background-color: #fee;
-        border: 2px solid #f00;
-        color: #c00;
-        padding: 16px;
-        margin-bottom: 24px;
-        border-radius: 4px;
-        font-weight: bold;
-        font-size: 14px;
-    `;
-    summary.textContent = message;
-
-    // カードの先頭に挿入
-    const card = stepElement.querySelector('.card');
-    if (card) {
-        card.insertBefore(summary, card.firstChild);
-    }
+    // デバッグ用のエラーサマリーは画面に表示しない
+    // コンソールログのみで十分
+    console.log('[ERROR SUMMARY]', message);
 }
 
 // エラーサマリーを非表示（デバッグ用）
 function hideErrorSummary(stepElement) {
-    const summary = stepElement.querySelector('.debug-error-summary');
-    if (summary) {
-        summary.remove();
-    }
+    // 何もしない（画面表示を削除したため）
 }
 
 // バリデーション


### PR DESCRIPTION
- Remove debug error summary display that was showing English error messages at the top of forms (step 7 and all other steps)
- Change progress section from position: sticky to position: relative on mobile to prevent it from hiding step 8 form content
- Keep console logging for debugging purposes

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)