### PR TITLE
fix: ステップ8の表示問題を修正（ステップ9スキップロジック追加）

### DIFF
--- a/js/pages/application-form.js
+++ b/js/pages/application-form.js
@@ -11,7 +11,7 @@
 
 // グローバル変数
 let currentStep = 1;
-const totalSteps = 9;
+const totalSteps = 10;
 let formData = {};
 
 // モバイルデバイス判定（スマホ・タブレット対応）
@@ -30,7 +30,7 @@ const steps = [
     { id: 6, label: '事業主情報', role: 'employer' },
     { id: 7, label: '医療機関', role: 'medical' },
     { id: 8, label: '診断証明', role: 'medical' },
-    { id: 9, label: '確認・提出', role: 'worker' }
+    { id: 10, label: '確認・提出', role: 'worker' }
 ];
 
 // 労災保険指定医療機関データ（30件のサンプルデータ）
@@ -763,6 +763,12 @@ function nextStep() {
         }
 
         currentStep++;
+
+        // ステップ9は存在しないため、ステップ8の次はステップ10にスキップ
+        if (currentStep === 9) {
+            currentStep = 10;
+        }
+
         console.log('[DEBUG] New currentStep:', currentStep, 'totalSteps:', totalSteps);
 
         if (currentStep <= totalSteps) {
@@ -817,6 +823,11 @@ function nextStepDev() {
     document.getElementById(`step-${currentStep}`).classList.remove('active');
     currentStep++;
 
+    // ステップ9は存在しないため、ステップ8の次はステップ10にスキップ
+    if (currentStep === 9) {
+        currentStep = 10;
+    }
+
     if (currentStep <= totalSteps) {
         const nextStepElement = document.getElementById(`step-${currentStep}`);
         if (nextStepElement) {
@@ -833,6 +844,11 @@ function previousStep() {
 
     document.getElementById(`step-${currentStep}`).classList.remove('active');
     currentStep--;
+
+    // ステップ9は存在しないため、ステップ10の前はステップ8にスキップ
+    if (currentStep === 9) {
+        currentStep = 8;
+    }
 
     if (currentStep >= 1) {
         document.getElementById(`step-${currentStep}`).classList.add('active');


### PR DESCRIPTION
HTMLにはステップ9が存在せず、ステップ8の次はステップ10に遷移する必要があるため、
JavaScriptのステップナビゲーションロジックにステップ9をスキップする処理を追加。

変更内容:
- totalStepsを9から10に変更
- steps配列のステップ9をステップ10に変更
- nextStep(), nextStepDev(), previousStep()関数にステップ9スキップロジックを追加

これによりステップ8のフォームコンテンツが正常に表示されるようになります。