### PR TITLE
fix: ステップ8が表示されない問題を修正

### DIFF
--- a/js/pages/application-form.js
+++ b/js/pages/application-form.js
@@ -776,6 +776,7 @@ function nextStep() {
             console.log('[DEBUG] Next step element (step-' + currentStep + '):', nextStepElement);
             if (nextStepElement) {
                 nextStepElement.classList.add('active');
+                nextStepElement.style.display = ''; // インラインスタイルをクリアしてCSSに任せる
                 console.log('[DEBUG] Added active class to step-' + currentStep);
                 console.log('[DEBUG] Element display:', window.getComputedStyle(nextStepElement).display);
             } else {
@@ -832,6 +833,7 @@ function nextStepDev() {
         const nextStepElement = document.getElementById(`step-${currentStep}`);
         if (nextStepElement) {
             nextStepElement.classList.add('active');
+            nextStepElement.style.display = ''; // インラインスタイルをクリアしてCSSに任せる
         }
         updateProgress();
         window.scrollTo(0, 0);
@@ -851,7 +853,11 @@ function previousStep() {
     }
 
     if (currentStep >= 1) {
-        document.getElementById(`step-${currentStep}`).classList.add('active');
+        const prevStepElement = document.getElementById(`step-${currentStep}`);
+        if (prevStepElement) {
+            prevStepElement.classList.add('active');
+            prevStepElement.style.display = ''; // インラインスタイルをクリアしてCSSに任せる
+        }
         updateProgress();
         window.scrollTo(0, 0);
     }


### PR DESCRIPTION
開発用ボタン（事業主・医療機関）使用後にステップ8に遷移すると、
プログレスバーより下の要素が表示されない問題を修正。

問題の原因:
- goToEmployerMode()とgoToMedicalMode()関数が全ステップに style.display='none'をインラインスタイルで設定
- その後のステップナビゲーションでactiveクラスのみ追加
- インラインスタイルはCSSクラスより優先度が高いため非表示のまま

修正内容:
- nextStep()、nextStepDev()、previousStep()関数で ステップ要素を表示する際にstyle.display=''を設定
- これによりインラインスタイルをクリアしてCSSに制御を任せる

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)