### PR TITLE
Fix step 8 display issue by adding missing error-summary CSS styles

### DIFF
--- a/css/pages/application-form.css
+++ b/css/pages/application-form.css
@@ -542,6 +542,70 @@ body {
     flex-shrink: 0;
 }
 
+/* エラーサマリー */
+.error-summary {
+    display: none;
+    margin-bottom: var(--spacing-6);
+    padding: var(--spacing-4);
+    background-color: var(--color-error-bg);
+    border: 1px solid var(--color-error);
+    border-radius: var(--radius-base);
+    animation: shake 0.3s ease-in-out;
+}
+
+.error-summary.show {
+    display: block;
+}
+
+.error-summary-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    color: var(--color-error);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-base);
+    margin-bottom: var(--spacing-3);
+}
+
+.error-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.error-summary-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.error-summary-list li {
+    padding: var(--spacing-2) 0;
+    padding-left: var(--spacing-6);
+    color: var(--color-error);
+    font-size: var(--font-size-sm);
+    position: relative;
+}
+
+.error-summary-list li::before {
+    content: '•';
+    position: absolute;
+    left: var(--spacing-3);
+    font-weight: var(--font-weight-bold);
+}
+
+@keyframes shake {
+    0%, 100% {
+        transform: translateX(0);
+    }
+    10%, 30%, 50%, 70%, 90% {
+        transform: translateX(-5px);
+    }
+    20%, 40%, 60%, 80% {
+        transform: translateX(5px);
+    }
+}
+
 
 /* ============================================
    ボタン - デジタル庁デザインシステム準拠


### PR DESCRIPTION
## Summary

Fixed the step 8 form input area not displaying by adding missing CSS styles for the error-summary component.

## Changes

- Added `.error-summary` CSS class with proper styling
- Added `.error-summary-header` with icon support
- Added `.error-summary-list` with custom bullets
- Added shake animation for visual feedback
- All styles follow Digital Agency Design System guidelines

## Root Cause

Step 8's HTML referenced error-summary CSS classes that didn't exist in the stylesheet, causing the entire form section to break and not display.

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)