### PR TITLE
プログレスバーの総ステップ数を10から9に修正

### DIFF
--- a/js/pages/application-form.js
+++ b/js/pages/application-form.js
@@ -11,7 +11,7 @@
 
 // グローバル変数
 let currentStep = 1;
-const totalSteps = 10;
+const totalSteps = 9;
 let formData = {};
 
 // モバイルデバイス判定（スマホ・タブレット対応）
@@ -30,7 +30,7 @@ const steps = [
     { id: 6, label: '事業主情報', role: 'employer' },
     { id: 7, label: '医療機関', role: 'medical' },
     { id: 8, label: '診断証明', role: 'medical' },
-    { id: 10, label: '確認・提出', role: 'worker' }
+    { id: 9, label: '確認・提出', role: 'worker' }
 ];
 
 // 労災保険指定医療機関データ（30件のサンプルデータ）


### PR DESCRIPTION
## Summary

Fixed the progress bar to display "ステップ X / 9" instead of "ステップ X / 10", as there are only 9 progress steps in the form.

## Changes

- Changed `totalSteps` from 10 to 9 in `js/pages/application-form.js`
- Updated the last step in the `steps` array from `id: 10` to `id: 9`

## Technical Details

The HTML structure has steps 1-8 and step 10 (step 9 doesn't exist in HTML). The `getProgressStep()` function correctly maps HTML step 10 to progress step 9, so the total progress steps should be 9, not 10.

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/chanitarou/rousai-assist/actions/runs/18968678026