### PR TITLE
fix: プログレスステップが生成されず初期表示でステップ6が表示される問題を修正

### DIFF
--- a/js/pages/application-form/FormNavigator.js
+++ b/js/pages/application-form/FormNavigator.js
@@ -262,7 +262,7 @@ export class FormNavigator {
      * @param {number} currentProgressStep - 現在の進捗ステップ
      */
     updateProgressItems(currentProgressStep) {
-        const progressItems = document.querySelectorAll('.progress-item');
+        const progressItems = document.querySelectorAll('.progress-step');
         progressItems.forEach((item, index) => {
             const stepNum = index + 1;
             if (stepNum < currentProgressStep) {
@@ -338,7 +338,7 @@ export class FormNavigator {
      */
     initializeProgress() {
         const currentStep = this.formState.getCurrentStep();
-        const progressItems = document.querySelectorAll('.progress-item');
+        const progressItems = document.querySelectorAll('.progress-step');
 
         // HTMLの進捗アイテムは9個（ステップ1-8、ステップ10）
         // data-step属性に基づいて各アイテムを更新

--- a/js/pages/application-form/index.js
+++ b/js/pages/application-form/index.js
@@ -67,6 +67,9 @@ async function initializeApplication() {
         // 既存のフォームデータを復元
         loadFormData();
 
+        // プログレス要素の生成
+        generateProgressSteps();
+
         // UI初期化
         initializeUI();
 
@@ -97,6 +100,45 @@ async function initializeApplication() {
         logger.error('アプリケーションの初期化に失敗しました', error);
         alert('申請フォームの初期化に失敗しました。ページを再読み込みしてください。');
     }
+}
+
+/**
+ * プログレスステップの生成
+ */
+function generateProgressSteps() {
+    const progressStepsContainer = document.getElementById('progressSteps');
+    if (!progressStepsContainer) {
+        logger.warn('progressSteps container not found');
+        return;
+    }
+
+    // プログレス要素をクリア
+    progressStepsContainer.innerHTML = '';
+
+    // STEP_DEFINITIONSからプログレスアイテムを生成
+    STEP_DEFINITIONS.forEach((step) => {
+        const progressStep = document.createElement('div');
+        progressStep.className = 'progress-step';
+        progressStep.setAttribute('data-step', step.id);
+
+        const indicator = document.createElement('div');
+        indicator.className = 'progress-step-indicator';
+        indicator.textContent = step.id;
+
+        const label = document.createElement('div');
+        label.className = 'progress-step-label';
+        label.textContent = step.label;
+
+        const line = document.createElement('div');
+        line.className = 'progress-step-line';
+
+        progressStep.appendChild(indicator);
+        progressStep.appendChild(label);
+        progressStep.appendChild(line);
+        progressStepsContainer.appendChild(progressStep);
+    });
+
+    logger.debug('Progress steps generated:', STEP_DEFINITIONS.length);
 }
 
 /**


### PR DESCRIPTION
## 概要
申請画面の初期表示時にステップ6が表示される問題を修正しました。

## 変更内容
- generateProgressSteps()関数を追加してSTEP_DEFINITIONSから進捗要素を動的生成
- セレクタを.progress-itemから.progress-stepに修正（既存CSSに合わせる）
- プログレス生成をUI初期化の前に実行してステップ1が正しく表示されるように修正

Fixes #35

🤖 Generated with [Claude Code](https://claude.ai/code)